### PR TITLE
Fix formatting issue in InterpolationParsingValidationTest

### DIFF
--- a/Editor/Tests/InterpolationParsingValidationTest.cs
+++ b/Editor/Tests/InterpolationParsingValidationTest.cs
@@ -39,4 +39,3 @@ namespace SuperEditor.Tests
         }
     }
 }
-}


### PR DESCRIPTION
Removed an extra right curly bracket at the end of the file which was causing a compilation error.